### PR TITLE
Debounce vs Throttle: Fix broken "onClick" callback when pressing on button's top

### DIFF
--- a/content/posts/debounce-vs-throttle/components/VendingMachine.jsx
+++ b/content/posts/debounce-vs-throttle/components/VendingMachine.jsx
@@ -49,6 +49,7 @@ const RedButton = styled.button`
   --button-height: 25px;
 
   position: absolute;
+  padding: 0;
 
   background-color: #ff4d4d;
   border-radius: 50%;
@@ -424,7 +425,7 @@ export const VendingMachine = ({
     <VendingMachineContainer width="100%" maxWidth="280px" maxWidthMd="350px">
       {!shouldThrowBall && <OutOfBalls onButtonClick={handleResetClick} />}
       <ButtonContainer bottom={150} bottomMd={175}>
-        <RedButton onClick={() => onButtonClick(throwBall)} />
+        <RedButton onMouseDown={() => onButtonClick(throwBall)} />
       </ButtonContainer>
       <StyledImage
         ref={setIntersectionRef}


### PR DESCRIPTION
Dispatches `onClick` callback of the vendor machine's button during `onMouseDown` event. Since the button moves, when you fire `mouseUp` event you are no longer hovering the button when clicked on its top area. 

- Closes #12 